### PR TITLE
Bug that prevents using app pulled from GitHub

### DIFF
--- a/WpfApp/ViewModel/PersonDetailsViewModel.cs
+++ b/WpfApp/ViewModel/PersonDetailsViewModel.cs
@@ -26,7 +26,7 @@ namespace WpfApp.ViewModel
 		public PersonDetailsViewModel(IPersonService personService, IDispatcher dispatcher, IEventAggregator aggregator, IDialogService dialogService) 
 			: base(personService, dispatcher, aggregator, dialogService)
 		{
-			aggregator.GetEvent<SelectedPersonChangeEvent>().Subscribe(OnSelectedPersonChanged, ThreadOption.BackgroundThread);
+			aggregator.GetEvent<SelectedPersonChangeEvent>().Subscribe(OnSelectedPersonChanged, ThreadOption.PublisherThread);
 
 			NewPersonCommand = new DelegateCommand(NewPerson);
 			EditPersonCommand = new DelegateCommand(EditPerson, CanEditPerson);


### PR DESCRIPTION
Hi, 

I have found your article on MVVM (http://blog.zuehlke.com/en/mvvm-and-unit-testing/) and pulled down the app. But running it creates fatal exception. I haven't look at the code too much so I just pin-point the exception source and change thread option so with this change the app work's as expected

**Description:**
When ChangePerson event is fired, the processing is done in thread, but
if that is background thread then it can't use Person parameter saying:
'The calling thread cannot access this object because a different thread
owns it.'

Simple cure is change the thread from Background to Publisher.
